### PR TITLE
Minor update in set_environment.sh (Correct certs path)

### DIFF
--- a/elk/set_environment.sh
+++ b/elk/set_environment.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Create required folders
-mkdir -p elk/pki/tls/certs && mkdir -p elk/pki/tls/private
+mkdir -p pki/tls/certs && mkdir -p pki/tls/private
 # Create server key and certificate
 openssl req -subj '/CN=docker.elk /' -x509 -days 3650 -nodes -batch -newkey rsa:2048 -keyout pki/tls/private/logstash.key -out pki/tls/certs/logstash.crt
 # Set vm.max_map_count


### PR DESCRIPTION
I failed testing your dockerized elk stack using the commands in your README because of an error in set_environment.sh file. In fact, you creates _certs/pki_ directory but you made calls to _pki_ directory from current directory. This pull request is to correct that.